### PR TITLE
fix bug and add test to fix red annotation visualization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.pth filter=lfs diff=lfs merge=lfs -text

--- a/comic/vis/visualize.py
+++ b/comic/vis/visualize.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 import matplotlib.patheffects as path_effects
@@ -42,10 +44,10 @@ def draw_box(ax, box, color):
 def draw_mask(ax, mask, color):
     alpha = 0.5
     threshold = 0.05
-    my_cmap = cm.jet
+    my_cmap = copy(cm.jet)
     my_cmap.set_under('k', alpha=0)
     my_cmap.set_over(color, alpha=alpha)
-    ax.imshow(mask.data.cpu()[:,:], cmap=my_cmap, clim=[threshold, threshold + 0.0001])
+    ax.imshow(mask.data.cpu()[:, :], cmap=my_cmap, clim=[threshold, threshold + 0.0001])
 
 
 def draw_annotation(img, ann, show_masks=False, ax=None, figsize:tuple=(3,3)):

--- a/data/minidata/Nakaguma-Talk-1000x543.jpg
+++ b/data/minidata/Nakaguma-Talk-1000x543.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e937cb41879a50010cea2a84fd65275c371ff08d14953cc80ad0d3b68ae89252
+size 198927

--- a/data/model/box_detector.pth
+++ b/data/model/box_detector.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b48dc1ceaace7bc9c1d1023abd88d08bcd9fe5ac1b5900baee90141dc0ba651
+size 165699670

--- a/data/model/text_detector.pth
+++ b/data/model/text_detector.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21e1ad112ff4735f8d482bcf91437dd6d5cc8621f6bb933962ccced59f7d13ab
+size 176196219

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Cython
 pycocotools
 google-cloud-storage
 functions-framework==1.5.0
+pytest==6.0.1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,47 @@
+import os
+import pathlib
+import pytest
+import shutil
+from skimage.io import imread
+
+
+def _datadir(request):
+    filedir = pathlib.Path(__file__).parent.absolute()
+    dir = filedir / '_test_data' / request.node.name
+    shutil.rmtree(str(dir), ignore_errors=True)
+    os.makedirs(str(dir))
+    return dir
+
+
+@pytest.fixture
+def datadir(request):
+    """
+    Directory for storing test data for latter inspection.
+    """
+    return _datadir(request)
+
+
+@pytest.fixture
+def data_path():
+    """
+    Path to a folder with data.
+    """
+    return pathlib.Path(os.path.abspath(pathlib.Path(__file__) / '..' / '..' / 'data'))
+
+
+@pytest.fixture
+def minidata_path(data_path):
+    """
+    Path to minidata folder within data.
+    """
+    return data_path / 'minidata'
+
+
+@pytest.fixture
+def nakaguma_image_path(minidata_path):
+    return minidata_path / 'Nakaguma-Talk-1000x543.jpg'
+
+
+@pytest.fixture
+def nakaguma_image(nakaguma_image_path):
+    return imread(nakaguma_image_path)

--- a/test/test_draw_mask.py
+++ b/test/test_draw_mask.py
@@ -1,11 +1,10 @@
+import matplotlib.pyplot as plt
+import torch
 from skimage.io import imsave
 
 from comic.models.rcnn import get_model_instance_segmentation
 from comic.utils.filter import filter_outputs
 from comic.vis import draw_annotation
-import torch
-import matplotlib.pyplot as plt
-from torch import functional as F
 
 
 def test_draw_annotations(datadir, data_path, nakaguma_image):

--- a/test/test_draw_mask.py
+++ b/test/test_draw_mask.py
@@ -1,0 +1,30 @@
+from skimage.io import imsave
+
+from comic.models.rcnn import get_model_instance_segmentation
+from comic.utils.filter import filter_outputs
+from comic.vis import draw_annotation
+import torch
+import matplotlib.pyplot as plt
+from torch import functional as F
+
+
+def test_draw_annotations(datadir, data_path, nakaguma_image):
+    image = torch.FloatTensor(nakaguma_image) / 255
+    image = image.transpose(0, 2)
+    imsave(datadir / 'input.jpg', nakaguma_image)
+
+    model = get_model_instance_segmentation(num_classes=3, pretrained=False)
+    model.load_state_dict(torch.load(data_path / 'model' / 'text_detector.pth', map_location='cpu'))
+    model.to('cpu').eval()
+
+    with torch.no_grad():
+        model.eval()
+        out = model(image[None, ...])
+    prediction = filter_outputs(out)
+    assert len(prediction) == 1
+    assert len(prediction[0]['boxes']) == 12
+
+    fig, ax = plt.subplots(figsize=(15, 15))
+    for i, pred in enumerate(prediction):
+        draw_annotation(image, pred, ax=ax)
+        plt.savefig(datadir / f'annotation_{i}.jpg', bbox_inches='tight')

--- a/test/test_text_detection.py
+++ b/test/test_text_detection.py
@@ -7,7 +7,7 @@ from comic.utils.filter import filter_outputs
 from comic.vis import draw_annotation
 
 
-def test_draw_annotations(datadir, data_path, nakaguma_image):
+def test_text_detection(datadir, data_path, nakaguma_image):
     image = torch.FloatTensor(nakaguma_image) / 255
     image = image.transpose(0, 2)
     imsave(datadir / 'input.jpg', nakaguma_image)


### PR DESCRIPTION
Test Log:
```
(venv) dikobraz@berserk:~/Projects/comic-translate$ pytest
====================================================================== test session starts =======================================================================
platform linux -- Python 3.6.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/dikobraz/Projects/comic-translate
collected 1 item                                                                                                                                                 

test/test_draw_mask.py .                                                                                                                                   [100%]

======================================================================== warnings summary ========================================================================
venv/lib/python3.6/site-packages/torchvision/io/video.py:2
  /home/dikobraz/Projects/comic-translate/venv/lib/python3.6/site-packages/torchvision/io/video.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================== 1 passed, 1 warning in 4.30s ==================================================================
```
![annotation_0](https://user-images.githubusercontent.com/2404864/89721677-59e8b980-d995-11ea-9c77-b09cd9121073.jpg)
